### PR TITLE
Allow migrating user commits only

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,8 @@ GITLAB_API_URL=https://gitlab.{ORG_NAME}.io/api/v4
 CONTRIBUTED_PROJECTS=
 # Your personal GitLab Token.
 GITLAB_TOKEN=
+# Your GitLab username
+GITLAB_USERNAME=
 
 # GitHub vars
 # Replace the {UUSER_NAME} with your GitHub username and the {REPO_NAME_AS_IN_THE_GITHUB_URL} with yours

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -63,6 +63,7 @@ These instructions will guide you through the setup and execution of the Univers
    GITLAB_API_URL=https://gitlab.yourdomain.io/api/v4
    CONTRIBUTED_PROJECTS=123,456 # Optional: Specify project IDs to fetch commits from, separated by commas.
    GITLAB_TOKEN=your_gitlab_token
+   GITLAB_USERNAME=your_gitlab_username
 
    # GitHub Configuration
    GITHUB_API_URL=https://api.github.com/repos/your_username/your_repo

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -18,6 +18,7 @@ Configure the following variables related to GitLab:
 
 - `GITLAB_API_URL`: Set this to your GitLab instance's API URL. For GitLab.com users, this will be `https://gitlab.com/api/v4`.
 - `GITLAB_TOKEN`: Your personal access token from GitLab with `read_api` scope. [Create a GitLab access token](https://gitlab.com/-/profile/personal_access_tokens).
+- `GITLAB_USERNAME`: (Optional) Your GitLab username to fetch only commits authered by you.
 - `CONTRIBUTED_PROJECTS`: (Optional) A comma-separated list of project IDs you want to fetch commits from. If left empty, the tool will fetch commits from all projects you have access to.
 
 Example:

--- a/gitlab/client.go
+++ b/gitlab/client.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	gitlabToken         string
+	gitlabUsername      string
 	gitlabApiUrl        string
 	contributedProjects string
 )
@@ -24,6 +25,7 @@ func init() {
 	}
 
 	gitlabToken = os.Getenv("GITLAB_TOKEN")
+	gitlabUsername = os.Getenv("GITLAB_USERNAME")
 	gitlabApiUrl = os.Getenv("GITLAB_API_URL")
 	contributedProjects = os.Getenv("CONTRIBUTED_PROJECTS")
 }
@@ -76,14 +78,14 @@ func FetchProjects() ([]gitlab.Project, error) {
 
 func FetchCommitsForProject(projectID int) ([]gitlab.Commit, error) {
 	var allCommits []gitlab.Commit
-	baseURL := fmt.Sprintf("%s/projects/%d/repository/commits", gitlabApiUrl, projectID)
+	baseURL := fmt.Sprintf("%s/projects/%d/repository/commits?author=%s", gitlabApiUrl, projectID, gitlabUsername)
 
 	// Start fetching from the first page
 	page := 1
 	perPage := 100 // Adjust per_page to your preference
 
 	for {
-		url := fmt.Sprintf("%s?page=%d&per_page=%d", baseURL, page, perPage)
+		url := fmt.Sprintf("%s&page=%d&per_page=%d", baseURL, page, perPage)
 		request, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Allow migrating commits authored by a specific user by configuring the `GITLAB_USERNAME` env var.